### PR TITLE
Feat/add chat functionality

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,6 +10,7 @@ import "../css/app.scss"
 // Import deps with the dep name or local files with a relative path, for example:
 //
 //     import {Socket} from "phoenix"
-//     import socket from "./socket"
-//
+
+import socket from "./socket"
+
 import "phoenix_html"

--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -60,6 +60,15 @@ let chatRoomTitle = document.getElementById("title")
 if (chatRoomTitle) {
   let chatRoomName = chatRoomTitle.dataset.chatRoomName
   let channel = socket.channel(`chat_room:${chatRoomName}`, {})
+
+  let form = document.getElementById("new-message-form")
+  let messageInput = document.getElementById("message")
+  form.addEventListener("submit", event => {
+    event.preventDefault()
+    channel.push("new_message", {body: messageInput.value})
+    event.target.reset()
+  })
+
   channel.join()
     .receive("ok", resp => { console.log("Joined successfully", resp) })
     .receive("error", resp => { console.log("Unable to join", resp) })

--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -8,7 +8,7 @@
 // from the params if you are not using authentication.
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+let socket = new Socket("/socket", {params: {}})
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -55,9 +55,14 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
-channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+let chatRoomTitle = document.getElementById("title")
+
+if (chatRoomTitle) {
+  let chatRoomName = chatRoomTitle.dataset.chatRoomName
+  let channel = socket.channel(`chat_room:${chatRoomName}`, {})
+  channel.join()
+    .receive("ok", resp => { console.log("Joined successfully", resp) })
+    .receive("error", resp => { console.log("Unable to join", resp) })
+}
 
 export default socket

--- a/assets/js/socket.js
+++ b/assets/js/socket.js
@@ -63,10 +63,19 @@ if (chatRoomTitle) {
 
   let form = document.getElementById("new-message-form")
   let messageInput = document.getElementById("message")
+  let messages = document.querySelector("[data-role='messages']")
+
   form.addEventListener("submit", event => {
     event.preventDefault()
     channel.push("new_message", {body: messageInput.value})
     event.target.reset()
+  })
+
+  channel.on("new_message", payload => {
+    let messageItem = document.createElement("li")
+    messageItem.dataset.role = "message"
+    messageItem.innerText = payload.body
+    messages.appendChild(messageItem)
   })
 
   channel.join()

--- a/hiws.md
+++ b/hiws.md
@@ -1,0 +1,25 @@
+# How It Was Solved
+
+This file keeps a running log of times a developer is stuck, and what was done to solve the issue. 
+It also links to any resources used to solve the problem. Thus we tie the solution back to the commit itself for future reference. 
+
+# Making a test watcher for JS tests only
+
+    The tutorial offered only two options - watch assets every time `mix test` is run or watch assets in a separate tab manually when you want to run JS containing tests. Neither of these options seemed good enough. 
+
+    From this article [Phoenix Elixir Testing Beyond Mix Text](https://brooklinmyers.medium.com/phoenix-elixir-testing-beyond-mix-test-5b07de241001)
+
+    We can create a custom task: 
+
+    ```elixir
+        defp aliases do
+            "test.current": ["test --only current"] 
+        end
+    ```
+
+    and run it using `mix test.current` 
+
+    So the solution ended up being to create a `mix test.js` task 
+    And also to set the `preffered_cli_env` property to `:test` for `test.js` in the project def
+    in [mix.exs](mix.exs)
+    as described in this forum post answer [preferred_cli_env](https://elixirforum.com/t/how-do-i-set-the-env-at-alias/16304/4)

--- a/lib/chatter_web/channels/chat_room_channel.ex
+++ b/lib/chatter_web/channels/chat_room_channel.ex
@@ -1,0 +1,7 @@
+defmodule ChatterWeb.ChatRoomChannel do 
+    use ChatterWeb, :channel
+
+    def join("chat_room:" <> _room_name, _msg, socket) do
+        {:ok, socket} 
+    end
+end

--- a/lib/chatter_web/channels/chat_room_channel.ex
+++ b/lib/chatter_web/channels/chat_room_channel.ex
@@ -4,4 +4,9 @@ defmodule ChatterWeb.ChatRoomChannel do
     def join("chat_room:" <> _room_name, _msg, socket) do
         {:ok, socket} 
     end
+
+    def handle_in("new_message", payload, socket) do
+        broadcast(socket, "new_message", payload)
+        {:noreply, socket} 
+    end
 end

--- a/lib/chatter_web/channels/user_socket.ex
+++ b/lib/chatter_web/channels/user_socket.ex
@@ -3,6 +3,7 @@ defmodule ChatterWeb.UserSocket do
 
   ## Channels
   # channel "room:*", ChatterWeb.RoomChannel
+  channel "chat_room:*", ChatterWeb.ChatRoomChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/lib/chatter_web/templates/chat_room/index.html.eex
+++ b/lib/chatter_web/templates/chat_room/index.html.eex
@@ -3,7 +3,7 @@
 <ul>
     <%= for room <- @chat_rooms do%>
         <li data-role = "room">
-            <%= room.name %>
+            <%= link room.name, to: Routes.chat_room_path(@conn, :show, room) %>
         </li>
     <% end %>
     <div>

--- a/lib/chatter_web/templates/chat_room/show.html.eex
+++ b/lib/chatter_web/templates/chat_room/show.html.eex
@@ -1,9 +1,9 @@
 <%= content_tag(:h1, id: "title", data: [role: "room-title", chat_room_name: @chat_room.name]) do %>
     <%= @chat_room.name %>
 <% end %>
-<form>
+<form id="new-message-form">
     <label>
-        New Message <input id="message" name="message" type="text">
+        New Message <input id="message" name="message" type="text" />
     </label>
     <button type="submit">Send</button>
 </form>

--- a/lib/chatter_web/templates/chat_room/show.html.eex
+++ b/lib/chatter_web/templates/chat_room/show.html.eex
@@ -1,6 +1,12 @@
 <%= content_tag(:h1, id: "title", data: [role: "room-title", chat_room_name: @chat_room.name]) do %>
     <%= @chat_room.name %>
 <% end %>
+
+<div>
+    <ul data-role="messages">
+    <ul>
+</div>
+
 <form id="new-message-form">
     <label>
         New Message <input id="message" name="message" type="text" />

--- a/lib/chatter_web/templates/chat_room/show.html.eex
+++ b/lib/chatter_web/templates/chat_room/show.html.eex
@@ -1,6 +1,6 @@
-<h1 data-role="room-title">
+<%= content_tag(:h1, id: "title", data: [role: "room-title", chat_room_name: @chat_room.name]) do %>
     <%= @chat_room.name %>
-</h1>
+<% end %>
 <form>
     <label>
         New Message <input id="message" name="message" type="text">

--- a/lib/chatter_web/templates/chat_room/show.html.eex
+++ b/lib/chatter_web/templates/chat_room/show.html.eex
@@ -1,3 +1,9 @@
 <h1 data-role="room-title">
     <%= @chat_room.name %>
 </h1>
+<form>
+    <label>
+        New Message <input id="message" name="message" type="text">
+    </label>
+    <button type="submit">Send</button>
+</form>

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,10 @@ defmodule Chatter.MixProject do
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      preferred_cli_env: [
+        "test.js": :test,
+      ]
     ]
   end
 
@@ -62,7 +65,16 @@ defmodule Chatter.MixProject do
       setup: ["deps.get", "ecto.setup", "cmd npm install --prefix assets"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      "test.js": ["assets.compile", "ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      "assets.compile": &compile_assets/1,
     ]
+  end
+
+  defp compile_assets(_) do
+    Mix.shell().cmd(
+      "cd assets && ./node_modules/webpack/bin/webpack.js --mode development",
+      quiet: true,
+    ) 
   end
 end

--- a/test/chatter_web/channels/chat_room_channel_test.exs
+++ b/test/chatter_web/channels/chat_room_channel_test.exs
@@ -1,0 +1,20 @@
+defmodule ChatterWeb.ChatRoomChannelTest do
+    use ChatterWeb.ChannelCase, async: true 
+    
+    describe "new message event" do
+        test "broadcasts message to all users" do
+            {:ok, _, socket} = join_channel("chat_room:general")
+            payload = %{"body" => "hello world!"}
+            
+            push(socket, "new_message", payload)
+
+            assert_broadcast "new_message", ^payload
+        end 
+    end
+
+    defp join_channel(topic) do
+        ChatterWeb.UserSocket
+        |> socket("", %{})
+        |> subscribe_and_join(ChatterWeb.ChatRoomChannel, topic) 
+    end
+end

--- a/test/chatter_web/features/user_can_chat_test.exs
+++ b/test/chatter_web/features/user_can_chat_test.exs
@@ -48,6 +48,6 @@ defmodule ChatterWeb.UserCanChatTest do
     end
 
     defp message(text) do
-        Query.data("data", "message", text: text)
+        Query.data("role", "message", text: text)
     end
 end

--- a/test/chatter_web/features/user_can_chat_test.exs
+++ b/test/chatter_web/features/user_can_chat_test.exs
@@ -1,0 +1,53 @@
+defmodule ChatterWeb.UserCanChatTest do
+    use ChatterWeb.FeatureCase, async: true 
+    
+    test "user can chat with others successfully", %{metadata: metadata} do
+        room = insert(:chat_room)
+        
+        # Both user and other_user are actually sessions for said users
+        user = 
+            metadata
+            |> new_user()
+            |> visit(rooms_index())
+            |> join_room(room.name)
+
+        other_user = 
+            metadata
+            |> new_user()
+            |> visit(rooms_index())
+            |> join_room(room.name)
+
+        user
+        |>  add_message("Hi everyone")
+
+        other_user
+        |> assert_has(message("Hi everyone"))
+        |> add_message("Hi, welcome to #{room.name}")
+
+        user
+        |> assert_has(message("Hi, welcome to #{room.name}"))
+
+    end
+
+    defp new_user(metadata) do
+        {:ok, user} = Wallaby.start_session(metadata: metadata)
+        user # this is really the session
+    end
+
+    defp rooms_index, do: Routes.chat_room_path(@endpoint, :index)
+
+    defp join_room(session, name) do
+        session
+        |> click(Query.link(name))
+    end
+
+    defp add_message(session, message) do
+        session
+        |> fill_in(Query.text_field("New Message"), with: message)
+        |> click(Query.button("Send"))
+    end
+
+    defp message(text) do
+        Query.data("data", "message", text: text)
+    end
+end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -21,6 +21,6 @@ defmodule ChatterWeb.FeatureCase do
   
       metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(Chatter.Repo, self())
       {:ok, session} = Wallaby.start_session(metadata: metadata)
-      {:ok, session: session}
+      {:ok, session: session, metadata: metadata}
     end
   end


### PR DESCRIPTION
Add capability for more than one session in feature tests. Set up sockets for chatting. Add new test alias for tests that need to use js. Give show template form for chat messages and display chat messages. Write passing feature test for two users chatting, and passing unit test for handling messages via handle_in/3. 